### PR TITLE
[unit] to overwrite it is enough to copy

### DIFF
--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -376,7 +376,6 @@ void Operation::from_vault(QString const &data_type
             if (overwrite) {
                 options["force"] = true;
                 fn = [src, dst, dst_dir, &options]() {
-                    os::rmtree(dst);
                     os::cptree(src, dst_dir, std::move(options));
                 };
             } else {


### PR DESCRIPTION
Overwrite option means existing data should be overwritten even if
existing data is newer. If there are some other files they should be
untouched.

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
