### PR TITLE
[qml] error signal passes variant map instead of string

### DIFF
--- a/qml/Vault/vault.cpp
+++ b/qml/Vault/vault.cpp
@@ -96,14 +96,16 @@ public:
             data["src"] = m_transfer->getSrc();
             emit done(Vault::ExportImportPrepare, data);
         } catch (error::Error e) {
-            emit error(Vault::ExportImportPrepare, e.what());
+            emit error(Vault::ExportImportPrepare, e.m);
         }
     }
 
     Q_INVOKABLE void eiExecute()
     {
         if (!m_transfer) {
-            emit error(Vault::ExportImportExecute, "exportImportPrepare was not called");
+            emit error(Vault::ExportImportExecute
+                       , map({{"message", "exportImportPrepare was not called"}
+                               , {"reason", "Logic"}}));
             return;
         }
         try {
@@ -112,7 +114,7 @@ public:
             });
             emit done(Vault::ExportImportExecute, QVariantMap());
         } catch (error::Error e) {
-            emit error(Vault::ExportImportExecute, e.what());
+            emit error(Vault::ExportImportExecute, e.m);
         }
     }
 
@@ -136,7 +138,7 @@ public:
                 init(root);
             } catch (error::Error e) {
                 debug::error("Error reconnecting", e.what());
-                emit error(Vault::RemoveSnapshot, e.what());
+                emit error(Vault::RemoveSnapshot, e.m);
             }
         } else {
             debug::debug("There are some snapshots, continue");
@@ -146,7 +148,7 @@ public:
 
 signals:
     void progress(Vault::Operation op, const QVariantMap &map);
-    void error(Vault::Operation op, const QString &error);
+    void error(Vault::Operation op, const QVariantMap &error);
     void done(Vault::Operation op, const QVariantMap &);
 
 public:
@@ -214,7 +216,7 @@ void Vault::initWorker(bool reload)
         m_worker->init(m_root);
         emit done(Vault::Connect, QVariantMap());
     } catch (error::Error e) {
-        emit error(Vault::Connect, e.what());
+        emit error(Vault::Connect, e.m);
     }
 }
 

--- a/qml/Vault/vault.hpp
+++ b/qml/Vault/vault.hpp
@@ -59,7 +59,7 @@ signals:
 
     void done(Operation operation, const QVariantMap &data);
     void progress(Operation operation, const QVariantMap &data);
-    void error(Operation operation, const QString &error);
+    void error(Operation operation, const QVariantMap &error);
 
 private:
     void initWorker(bool reload);


### PR DESCRIPTION
It is used to pass reason (should be standard), message etc. It also
compatible with previous semantics

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
