### PR TITLE
Consider backup as failed if any unit is failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ units/vault-*
 *.moc
 tests/tests.xml
 tests/*_unit.cpp
-tests/*_vault_test
 src/config.hpp

--- a/include/vault/config.hpp
+++ b/include/vault/config.hpp
@@ -47,6 +47,7 @@ public:
     QString script() const;
     inline QVariantMap data() const { return m_data; }
 
+    bool isLocal() const { return is(m_data.value("local", QVariant(false))); }
 private:
     QVariantMap m_data;
 };

--- a/src/vault.cpp
+++ b/src/vault.cpp
@@ -180,8 +180,12 @@ int Vault::execute(const QVariantMap &options)
         if (!options.contains("data")) {
             error::raise({{"action", action}, {"msg", "Needs data"}});
         }
-        qDebug()<<parseKvPairs(options.value("data").toString());
-        vault.registerConfig(parseKvPairs(options.value("data").toString()));
+        auto data = parseKvPairs(str(options["data"]));
+        if (options.contains("unit"))
+            data["unit"] = options["unit"];
+        data["local"] = true;
+        debug::info("Register local unit:", data);
+        vault.registerConfig(data);
     } else if (action == "unregister") {
         if (!options.contains("unit")) {
             error::raise({{"action", action}, {"msg", "Needs unit name"}});

--- a/src/vault.cpp
+++ b/src/vault.cpp
@@ -337,8 +337,13 @@ void Vault::setup(const QVariantMap *config)
     } else if (config) {
         debug::info("Repository initialization is requested");
 
-        if (os::path::exists(m_path))
-            error::raise({{"msg", "Vault dir already exists, can't create"}, {"path", m_path}});
+        if (os::path::exists(m_path)) {
+            QDir d(m_path);
+            if (!d.entryList(QDir::NoDotAndDotDot).isEmpty())
+                error::raise({
+                        {"msg", "Vault dir already exists and not empty"}
+                        , {"path", m_path}});
+        }
 
         try {
             createRepo();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ ENDMACRO(UNIT_IMPL)
 
 UNIT_IMPL(unit1)
 UNIT_IMPL(unit2)
+install(PROGRAMS unit_fail_vault_test DESTINATION ${TESTS_DIR})
 
 configure_file(tests.xml.in tests.xml @ONLY)
 install(FILES tests.xml DESTINATION ${TESTS_DIR})

--- a/tests/unit_fail_vault_test
+++ b/tests/unit_fail_vault_test
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "SHOULD FAIL"
+echo "FAIL UNIT is FAILED" >&2
+exit 1

--- a/tests/vault.cpp
+++ b/tests/vault.cpp
@@ -174,7 +174,7 @@ void object::test<tid_config_update>()
 
     units = vlt->config().units();
     ensure("no unit1 in vault config", units.contains("unit1"));
-    ensure("unit2 should be removed from vault config", !units.contains("unit2"));
+    ensure("local unit2 should not be removed", units.contains("unit2"));
     on_exit();
 }
 

--- a/tests/vault.cpp
+++ b/tests/vault.cpp
@@ -18,6 +18,7 @@
 #include <unistd.h>
 
 namespace os = qtaround::os;
+namespace subprocess = qtaround::subprocess;
 namespace error = qtaround::error;
 
 namespace tut
@@ -41,7 +42,8 @@ enum test_ids {
     tid_config_update,
     tid_simple_blobs,
     tid_clear,
-    tid_cli_backup_restore_several_units
+    tid_cli_backup_restore_several_units,
+    tid_backup_fail
 };
 
 namespace {
@@ -298,10 +300,52 @@ void object::test<tid_cli_backup_restore_several_units>()
     vault_init();
     register_unit(vault_dir, "unit1", false);
     register_unit(vault_dir, "unit2", false);
-    vault::Vault::execute({{"action", "export"}
+    auto rc = vault::Vault::execute({{"action", "export"}
             , {"vault", vault_dir}
             , {"home", home}
             , {"unit", "unit1,unit2"}});
+    ensure_eq("Should succeed", rc, 0);
+    on_exit();
+}
+
+template<> template<>
+void object::test<tid_backup_fail>()
+{
+    using vault::Vault;
+    auto on_exit = setup(tid_backup_fail);
+    auto describe = []() {
+        subprocess::Process ps;
+        ps.setWorkingDirectory(vault_dir);
+        ps.start("git", {"describe", "--tags", "--exact-match"});
+        return std::move(ps);
+    };
+    auto last_snapshot = []() {
+        return vlt->snapshots().last().name();
+    };
+    os::rmtree(home);
+    os::mkdir(home);
+    vault_init();
+    register_unit(vault_dir, "unit1", false);
+    register_unit(vault_dir, "unit2", false);
+    auto rc = Vault::execute({{"action", "export"}
+            , {"vault", vault_dir}
+            , {"home", home}
+            , {"unit", "unit1,unit2"}});
+    ensure_eq("These units should proceed", rc, 0);
+
+    auto snap1 = last_snapshot();
+
+    register_unit(vault_dir, "unit_fail", false);
+    rc = Vault::execute({{"action", "export"}
+            , {"vault", vault_dir}
+            , {"home", home}
+            , {"unit", "unit1,unit2,unit_fail"}});
+    ensure_eq("With failed unit it should fail", rc, 1);
+
+    auto ps = describe();
+    ensure("Git is not found", ps.wait(10));
+    ensure_eq("There should be a previous tag on top", ps.rc(), 0);
+    ensure_eq("Should be the same snapshot as before", snap1, last_snapshot());
     on_exit();
 }
 


### PR DESCRIPTION
Also do not match locally registered unit with the global one and allow to setup vault storage in the empty directory