### PR TITLE
[vault] fail if blob can't be hashed. Fixes MER#1306

### DIFF
--- a/src/vault.cpp
+++ b/src/vault.cpp
@@ -32,6 +32,8 @@ namespace debug = qtaround::debug;
 
 namespace vault {
 
+static const int sha1HashLength = 40;
+
 static const QMap<File, QString> fileNames = {
     {File::Message, ".message"}
     , {File::VersionTree, ".vault"}
@@ -661,6 +663,10 @@ struct Unit
     {
         QString blobStorage = os::path::join(m_vcs->path(), ".git", "blobs");
         QByteArray sha = m_vcs->hashObject(file);
+        if (sha.length() != sha1HashLength)
+            error::raise({{"msg", "Can't hash object"},
+                        {"file", file}, {"hash", str(sha)}});
+
         QString blobDir = os::path::join(blobStorage, sha.left(2));
         QString blobFName = os::path::join(blobDir, sha.mid(2));
         QString linkFName = os::path::join(m_vcs->path(), file);


### PR DESCRIPTION
Signed-off-by: Denis Zalevskiy <denis.zalevskiy@jolla.com>